### PR TITLE
Update for Zabbix 2.2.3

### DIFF
--- a/service-discovery/servdisc.ps1
+++ b/service-discovery/servdisc.ps1
@@ -3,22 +3,36 @@
 #
 
 # First, fetch the list of auto started services
-$colItems = Get-WmiObject Win32_Service | where-object { $_.StartMode -eq 'Auto' }
-
+$colItems = Get-WmiObject Win32_Service | where-object { $_.StartMode -ne 'Disabled' }
 # Output the JSON header
-write-host "{"
-write-host " `"data`":["
+Write-Host "{";
+write-host "`t ""data"":[";
 write-host
+
+#temp variable
+$temp = 1
 
 # For each object in the list of services, print the output of the JSON message with the object properties that we are interessted in
 foreach ($objItem in $colItems) {
- $line =  " { `"{#SERVICESTATE}`":`"" + $objItem.State + "`" , `"{#SERVICEDISPLAY}`":`"" + $objItem.DisplayName + "`" , `"{#SERVICENAME}`":`"" + $objItem.Name + "`" , `"{#SERVICEDESC}`":`"" + $objItem.Description + "`" },"
- write-host $line
+ $exe_dir = $objItem.PathName
+ $exe_dir = $exe_dir -replace '"?(.+\\).+exe.*','$1'
+ $exe_dir = $exe_dir -replace '\\','/'
+ 
+ $desc_val = $objItem.Description
+ $desc_val = $desc_val -replace '\"','@'
+ 
+ if ($temp -eq 0){
+	Write-Host ",";
+ } 
+ else{
+	$temp = 0;
+ }
+ $line = " { `"{#SERVICESTATE}`":`"" + $objItem.State + "`", `"{#SERVICEDISPLAY}`":`"" + $objItem.DisplayName + "`", `"{#SERVICENAME}`":`"" + $objItem.Name + "`", `"{#SERVICEDESC}`":`"" + $desc_val + "`", `"{#SERVICEDIR}`":`"" + $exe_dir + "`" }"
+ Write-Host -NoNewline $line
 }
 
 # Close the JSON message
 write-host
-write-host " ]"
-write-host "}"
 write-host
-
+write-host "`t ]";
+write-host "}"


### PR DESCRIPTION
The Zabbix 2.2.3 didn't reorganize the JSON format so I made some changes to be the same as the documentation. 
https://www.zabbix.com/documentation/doku.php?id=2.0/manual/discovery/low_level_discovery#discovery_item_json_format

Also from the $objItem.Description I removed the " " from the text.
